### PR TITLE
new dictionary paths for rstudio

### DIFF
--- a/R/hunspell.R
+++ b/R/hunspell.R
@@ -203,7 +203,12 @@ dicpath <- function(){
    "/usr/share/myspell",
    "/usr/share/myspell/dicts",
    "/Library/Spelling",
-   file.path(dirname(Sys.getenv("RMARKDOWN_MATHJAX_PATH")), "dictionaries") #Rstudio
+   #RStudio
+   file.path(dirname(Sys.getenv("RMARKDOWN_MATHJAX_PATH")), "dictionaries"),
+   normalizePath("~/.rstudio-desktop/dictionaries/languages-system", mustWork = FALSE),
+   normalizePath("~/.rstudio-desktop/dictionaries/languages-user", mustWork = FALSE),
+   normalizePath("%USERPROFILE%/Local Settings/Application Data/RStudio-Desktop/dictionaries/languages-user", mustWork = FALSE),
+   normalizePath("%localappdata%/RStudio-Desktop/dictionaries/languages-user", mustWork = FALSE)
   )
 }
 


### PR DESCRIPTION
RStudio seems to store its dictionaries at another place now? 

https://support.rstudio.com/hc/en-us/articles/200551916-Spelling-Dictionaries

Didn't test this on windows. So please consider with caution. 