### PR TITLE
Handling a vector of dictionaries in get_dict

### DIFF
--- a/R/hunspell.R
+++ b/R/hunspell.R
@@ -187,8 +187,9 @@ get_affix <- function(dicpath){
 }
 
 get_dict <- function(dict){
-  if(!file.exists(dict)){
-    dict <- find_in_dicpath(paste0(sub("\\.(dic|aff)$", "", dict), ".dic"))
+  found <- file.exists(dict)
+  if(!all(found)){
+    dict[!found] <- sapply(paste0(sub("\\.(dic|aff)$", "", dict[!found]), ".dic"), find_in_dicpath)
   }
   normalizePath(dict, mustWork = TRUE)
 }


### PR DESCRIPTION
In get_dict : 
- modified file.exists condition check to avoid length > 1 warning
- modified find_in_dicpath call to handle multiple unfound dict